### PR TITLE
[Adriyst's work !]Compaitibility script no longer breaks to collections changes in 3.10

### DIFF
--- a/pptx/compat/__init__.py
+++ b/pptx/compat/__init__.py
@@ -4,13 +4,13 @@
 
 import sys
 
-import collections
-
 try:
+    import collections.abc
     Container = collections.abc.Container
     Mapping = collections.abc.Mapping
     Sequence = collections.abc.Sequence
-except AttributeError:
+except ImportError:
+    import collections
     Container = collections.Container
     Mapping = collections.Mapping
     Sequence = collections.Sequence


### PR DESCRIPTION
This PR is for merging the commit against the [upstream](https://github.com/scanny/python-pptx/pull/771) created by [Adriyst](https://github.com/Adriyst) into zztkm/pyton-pptx(thins repo).